### PR TITLE
Corrects malformed meta-information lines (missing closing '>').

### DIFF
--- a/scripts/vcf-find-duplicate-from-union-sites
+++ b/scripts/vcf-find-duplicate-from-union-sites
@@ -681,7 +681,7 @@ if ( $chr eq $xLabel ) {
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n") unless ( defined($extHdrs{"CEN"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXTSVM,Description=\"Variant failed SVM filter from externally provided VCF\">\n") unless ( defined($extHdrs{"EXTSVM"}) );
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n") unless ( defined($extHdrs{"EXHET"}) );
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n") unless ( defined($extHdrs{"EXHET"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter from new training model\">\n") unless ( defined($extHdrs{"SVM"}) );    
     foreach my $key (keys %extHdrs) {
 	splice(@hdrs,$#hdrs,0,$extHdrs{$key});
@@ -925,7 +925,7 @@ else {
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n") unless ( defined($extHdrs{"CEN"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXTSVM,Description=\"Variant failed SVM filter from externally provided VCF\">\n") unless ( defined($extHdrs{"EXTSVM"}) );
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n") unless ( defined($extHdrs{"EXHET"}) );
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n") unless ( defined($extHdrs{"EXHET"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter from new training model\">\n") unless ( defined($extHdrs{"SVM"}) );
     foreach my $key (keys %extHdrs) {
 	splice(@hdrs,$#hdrs,0,$extHdrs{$key});

--- a/scripts/vcf-milk-svm-filter
+++ b/scripts/vcf-milk-svm-filter
@@ -543,13 +543,13 @@ foreach my $chr (@chrs) {
 	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n");    
 	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter\">\n");
 	splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
-	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\"\n");
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC10,Description=\"Mendelian or duplicate genotype discordance is high (11 or more)\"\n");    
-	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n");
-	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CHRXHET,Description=\"Excess heterozygosity in chrX\"\n"); 	
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHOM,Description=\"Excess homozygosity with HWE p-value < 1e-6\"\n");    
+	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\">\n");
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC10,Description=\"Mendelian or duplicate genotype discordance is high (11 or more)\">\n");    
+	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n");
+	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CHRXHET,Description=\"Excess heterozygosity in chrX\">\n"); 	
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHOM,Description=\"Excess homozygosity with HWE p-value < 1e-6\">\n");    
 	print OUT join("",@hdrs);
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CONFLICT,Description=\"Variant position conflicts with other variants with higher SVM score\"\n");
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CONFLICT,Description=\"Variant position conflicts with other variants with higher SVM score\">\n");
     #print OUTU join("",@hdrs);    
 	
 	#my %hbest = ();
@@ -759,12 +759,12 @@ foreach my $chr (@chrs) {
 	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n");    
 	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter\">\n");
 	splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
-	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\"\n");
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC10,Description=\"Mendelian or duplicate genotype discordance is high (11 or more)\"\n");    
-	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n");
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHOM,Description=\"Excess homozygosity with HWE p-value < 1e-6\"\n");    
+	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\">\n");
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC10,Description=\"Mendelian or duplicate genotype discordance is high (11 or more)\">\n");    
+	splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n");
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHOM,Description=\"Excess homozygosity with HWE p-value < 1e-6\">\n");    
 	print OUT join("",@hdrs);
-	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CONFLICT,Description=\"Variant position conflicts with other variants with higher SVM score\"\n");
+	#splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CONFLICT,Description=\"Variant position conflicts with other variants with higher SVM score\">\n");
     #print OUTU join("",@hdrs);    
 	
 	#my %hbest = ();

--- a/scripts/vcf-svm-ext-filter
+++ b/scripts/vcf-svm-ext-filter
@@ -680,7 +680,7 @@ if ( $chr eq $xLabel ) {
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n") unless ( defined($extHdrs{"CEN"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXTSVM,Description=\"Variant failed SVM filter from externally provided VCF\">\n") unless ( defined($extHdrs{"EXTSVM"}) );
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n") unless ( defined($extHdrs{"EXHET"}) );
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n") unless ( defined($extHdrs{"EXHET"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter from new training model\">\n") unless ( defined($extHdrs{"SVM"}) );    
     foreach my $key (keys %extHdrs) {
 	splice(@hdrs,$#hdrs,0,$extHdrs{$key});
@@ -924,7 +924,7 @@ else {
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n") unless ( defined($extHdrs{"CEN"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXTSVM,Description=\"Variant failed SVM filter from externally provided VCF\">\n") unless ( defined($extHdrs{"EXTSVM"}) );
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n") unless ( defined($extHdrs{"EXHET"}) );
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n") unless ( defined($extHdrs{"EXHET"}) );
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter from new training model\">\n") unless ( defined($extHdrs{"SVM"}) );
     foreach my $key (keys %extHdrs) {
 	splice(@hdrs,$#hdrs,0,$extHdrs{$key});

--- a/scripts/vcf-svm-generic-filter
+++ b/scripts/vcf-svm-generic-filter
@@ -370,8 +370,8 @@ if ( 1 > 0 ) {  ## this is a placeholder for adding chrX condition later on
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n");    
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter\">\n");
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=NEG,Description=\"Negatively labeled variants from external source\"\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=NEG,Description=\"Negatively labeled variants from external source\">\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n");
 
     print OUT join("",@hdrs);
         

--- a/scripts/vcf-svm-milk-filter
+++ b/scripts/vcf-svm-milk-filter
@@ -518,9 +518,9 @@ if ( $chr eq $xLabel ) {
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n");    
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter\">\n");
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\"\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CHRXHET,Description=\"Excess heterozygosity in chrX\"\n");  
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\">\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CHRXHET,Description=\"Excess heterozygosity in chrX\">\n");  
     print OUT join("",@hdrs);
     
     my $maxan = 0; 
@@ -726,8 +726,8 @@ else {
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=CEN,Description=\"Variant overlaps with centromeric region\">\n");    
     splice(@hdrs,$#hdrs,0,"##FILTER=<ID=SVM,Description=\"Variant failed SVM filter\">\n");
     splice(@hdrs,$#hdrs,0,"##INFO=<ID=OVERLAP,Number=.,Type=String,Description=\"Overlap with possible variant types\">\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\"\n");
-    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\"\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=DISC,Description=\"Mendelian or duplicate genotype discordance is high (3/5% or more)\">\n");
+    splice(@hdrs,$#hdrs,0,"##FILTER=<ID=EXHET,Description=\"Excess heterozygosity with HWE p-value < 1e-6\">\n");
 
     print OUT join("",@hdrs);
         


### PR DESCRIPTION
Some FILTER header lines are missing a closing '>' character. 